### PR TITLE
Add keyboard shortcuts to screenshotWindow

### DIFF
--- a/screenshotwindow.cpp
+++ b/screenshotwindow.cpp
@@ -77,6 +77,28 @@ screenshotWindow::~screenshotWindow()
     delete ui;
 }
 
+void screenshotWindow::keyPressEvent( QKeyEvent* event ) {
+    switch ( event->key() ) {
+    case Qt::Key_Escape:
+        //on ESC, close ui
+        on_discardButton_clicked();
+        break;
+    case Qt::Key_Enter: //We need to capture both Enter and Return since it can vary between keyboards
+        on_saveButton_clicked();
+        break;
+    case Qt::Key_Return:
+        on_saveButton_clicked();
+        break;
+    default:
+        if(Qt::Key_C && modifiers() & Qt::ControlModifier) {
+        on_copyButton_clicked();
+        break;
+        }
+        event->ignore();
+        break;
+    }
+}
+
 void screenshotWindow::paintEvent(QPaintEvent *event) {
     QPainter painter(this);
     painter.setBrush(QColor(0, 0, 0, 150));

--- a/screenshotwindow.h
+++ b/screenshotwindow.h
@@ -78,7 +78,8 @@ private:
     QRubberBand* band;
     QPoint bandOrigin;
     QRectF originalGeometry;
-
+    
+    void keyPressEvent(QKeyEvent* event);
     void paintEvent(QPaintEvent* event);
     bool eventFilter(QObject *object, QEvent *event);
 };


### PR DESCRIPTION
-  ESC key will exit the window
-  Enter/Return will save the current image
-  Ctrl+C will copy the current image to your clipboard

This change has **not** been tested for theShell, but it is pretty minor so I doubt that any issues should arise. Thanks!